### PR TITLE
fix: improve error message for not yet archived historical weather

### DIFF
--- a/src/modules/weather.rs
+++ b/src/modules/weather.rs
@@ -133,7 +133,7 @@ latitude={lat}
 			.with_context(|| "Historical weather data request failed.")?;
 
 		// It takes up to 5 days until temperature data is available in open-meteo's archive.
-		// Therefor we check for null values in the temperature.
+		// Therefore, we check for null values in the temperature.
 		if raw_res["hourly"]["temperature_2m"]
 			.as_array()
 			.expect("Failed decoding temperature data for historical weather.")[0]

--- a/src/modules/weather.rs
+++ b/src/modules/weather.rs
@@ -139,7 +139,7 @@ latitude={lat}
 			.expect("Failed decoding temperature data for historical weather.")[0]
 			.is_null()
 		{
-			return Err(anyhow!("The temperature for the requested weather has not yet been archived."));
+			return Err(anyhow!("The temperature for the requested day has not yet been archived."));
 		}
 
 		Ok(serde_json::from_value::<OptionalWeather>(raw_res)?)


### PR DESCRIPTION
An improved error message for historical weather data that is not yet available in open-meteo's archives. 

Resolves #135 