### PR TITLE
🤖 allow for Renovate lock file maintenances

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -17,7 +17,7 @@
   lockFileMaintenance: {
     commitMessageAction: "maintain Cargo.lock",
     commitMessagePrefix: "🤖",
-    enabled: false,
+    enabled: true,
     schedule: "* 0 * * MON",
   },
   packageRules: [


### PR DESCRIPTION
At the moment, Renovate cannot find any updates to Rust crates as the changes would only affect `Cargo.lock` but not `Cargo.toml` such that it does not suggest any update PRs.  As even Dependabot updates are nothing more than a lock file maintenance, this PR turns the lock file maintenance feature on which Renovate allows for in order to have all Dependabot Rust updates bundled in a single PR per week.