### PR TITLE
docs: clarify installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,43 +1,72 @@
+# Installation
+
+## Contents
+
+- [Requirements](https://github.com/ttytm/wthrr-the-weathercrab/blob/main/INSTALL.md#requirements)
+  - [Fonts](https://github.com/ttytm/wthrr-the-weathercrab/blob/main/INSTALL.md#fonts)
+  - [Other requirements](https://github.com/ttytm/wthrr-the-weathercrab#other-requirements)
+- [Installation](https://github.com/ttytm/wthrr-the-weathercrab/blob/main/INSTALL.md#installation)
+  - [Alternatives to cargo](https://github.com/ttytm/wthrr-the-weathercrab/blob/main/INSTALL.md#installation)
+  - [Build from source](https://github.com/ttytm/wthrr-the-weathercrab/blob/main/INSTALL.md#build-from-source)
+
 ## Requirements
 
-This app uses font symbols and emojis. Therefore, font configuration is the primary requirement.
+This app uses font symbols and Unicode characters. Since it runs in the terminal, it depends on the fonts available on the system and the terminal's font configuration.
 
-- Set your default terminal font to a nerd font.
-  - For installation check the nerd-fonts github repository: [ryanoasis/nerd-fonts](https://www.nerdfonts.com/font-downloads).
-  - Alternatively they are available on the nerdfonts website: [nerdfonts.com/font-downloads](https://github.com/ryanoasis/nerd-fonts).
-  - For installation via `brew`, see below.
-- A Unicode symbol font needs to be available on the system.
-  - If none is installed by default, noto font packages are usually available via your distribution's package manager.
+On windows it is advised to use [Windows Terminal](https://apps.microsoft.com/store/detail/windows-terminal/9N0DX20HK701) instead of the standard terminal.
 
-### Debian based distros
+### Fonts
 
-- Install package and font dependencies
+#### Nerd Font
+
+A nerd font is usually a regular font that is patched to include additional glyphs.
+The nerd-fonts github repository ([ryanoasis/nerd-fonts](https://www.nerdfonts.com/font-downloads)) or the nerdfonts website ([nerdfonts.com/font-downloads](https://github.com/ryanoasis/nerd-fonts)) provide a number of patched fonts. Download and install a font from the above mentioned sources or via your systems package manager if it makes the fonts available.
+
+**Make sure to configure your terminal to use the installed font.**
+
+- On macOS using `brew`
+
+  ```sh
+  brew tap homebrew/cask-fonts   # This is only required once
+  brew install font-jetbrains-mono-nerd-font  # Or any other nerd-font
+  ```
+
+- On Windows, you can follow the installation steps of [Oh My Posh](https://ohmyposh.dev/docs/installation/windows) to nerdify your power shell and install a Nerd Font.
+
+#### Unicode symbol font
+
+A Unicode symbol font("emoji-font") needs to be available on the system.
+It is required for emojis and things like line characters in the daily weather graph to be displayed properly on your system.
+Noto font packages are usually available via your distribution's package manager.
+
+It's enough to install the font, there is no need for configuration changes.
+
+- macOS
+
+  ```sh
+  brew install font-noto-sans-symbols-2  # Required when using e.g., iterm2 / alacritty
+  ```
+
+- Debian based distros
+
+  ```sh
+  sudo apt install fonts-noto-core
+  ```
+
+If you still encounter problems with the graph in the used terminal: Instead of searching for the correct font package, you can also try setting a different graph style in the [config](https://github.com/ttytm/wthrr-the-weathercrab#config).
+
+### Other requirements
+
+- Debian based distros
 
   ```
-  sudo apt install libssl-dev pkg-config fonts-noto-core
+  sudo apt install libssl-dev pkg-config
   ```
 
-- When using the binaries from the release page, you may need to add libssl manually
+  When using the binaries from the release page, you may need to add libssl manually
 
   ```
   wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb ; sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
-  ```
-
-### Arch Linux
-
-- `wthrr` can be installed from the [AUR](https://aur.archlinux.org/packages?O=0&SeB=nd&K=wthrr&outdated=&SB=p&SO=d&PP=50&submit=Go) using an [AUR helper](https://wiki.archlinux.org/title/AUR_helpers). For example:
-
-  ```
-  paru -S wthrr
-  ```
-
-### MacOS
-
-- Install cask-fonts, a unicode symbol font and a nerd font
-  ```
-  brew tap homebrew/cask-fonts
-  brew install font-noto-sans-symbols-2    # Required when using e.g., iterm2 / alacritty
-  brew install font-jetbrains-mono-nerd-font    # Or any other nerd-font
   ```
 
 ## Installation
@@ -57,6 +86,10 @@ There are several alternatives to `cargo install wthrr` from crates.io.
   ```
   ```
   nix run "github:tobealive/wthrr-the-weathercrab"
+  ```
+- On Arch Linux `wthrr` can be installed from the [AUR](https://aur.archlinux.org/packages?O=0&SeB=nd&K=wthrr&outdated=&SB=p&SO=d&PP=50&submit=Go) using an [AUR helper](https://wiki.archlinux.org/title/AUR_helpers). For example:
+  ```
+  paru -S wthrr
   ```
 
 ### Build from source

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ If you spend time in the TUI, you'll have a little companion nearby who knows ab
 
 ## Contents
 
-- [How to use?](https://github.com/tobealive/wthrr-the-weathercrab#how-to-use)
-- [Showcase](https://github.com/tobealive/wthrr-the-weathercrab#showcase)
-- [Config](https://github.com/tobealive/wthrr-the-weathercrab#config)
-- [Installation](https://github.com/tobealive/wthrr-the-weathercrab#installation)
-- [Outlook](https://github.com/tobealive/wthrr-the-weathercrab#outlook)
-- [Credits](https://github.com/tobealive/wthrr-the-weathercrab#credits)
+- [How to use?](https://github.com/ttytm/wthrr-the-weathercrab#how-to-use)
+- [Showcase](https://github.com/ttytm/wthrr-the-weathercrab#showcase)
+- [Config](https://github.com/ttytm/wthrr-the-weathercrab#config)
+- [Installation](https://github.com/ttytm/wthrr-the-weathercrab#installation)
+- [Outlook](https://github.com/ttytm/wthrr-the-weathercrab#outlook)
+- [Credits](https://github.com/ttytm/wthrr-the-weathercrab#credits)
 
 ## How to use?
 
@@ -34,7 +34,7 @@ If you spend time in the TUI, you'll have a little companion nearby who knows ab
 wthrr
 ```
 
-Without having added an address or options, wthrr uses the [config](https://github.com/tobealive/wthrr-the-weathercrab#config) saved as default.<br>
+Without having added an address or options, wthrr uses the [config](https://github.com/ttytm/wthrr-the-weathercrab#config) saved as default.<br>
 If you haven't configured anything as default yet, wthrr can try to search for a weather station near you and save the searched location as default.
 
 **It's always possible to specify an address.** E.g.,
@@ -174,20 +174,22 @@ Use rusts package manger to install wthrr's latest version.
 cargo install wthrr
 ```
 
-**Requirements and other installations methods can be found in [`INSTALL.md`](https://github.com/tobealive/wthrr-the-weathercrab/blob/main/INSTALL.md).**
+> **Note**
+> To display symbols correctly, the used terminal must be configured to use a NerdFont.
+> Requirements and platform-specific installation instructions can be found in [`INSTALL.md`](https://github.com/ttytm/wthrr-the-weathercrab/blob/main/INSTALL.md).
 
 ## Outlook
 
-The [issues](https://github.com/tobealive/wthrr-the-weathercrab/issues) section lists some of the features that are being worked on.
+The [issues](https://github.com/ttytm/wthrr-the-weathercrab/issues) section lists some of the features that are being worked on.
 
 Contributions like 🐛bug reports, ⭐️stars and 💡suggestions are welcome alike!
 
-A simple changelog can be found on the [releases page](https://github.com/tobealive/wthrr-the-weathercrab/releases).
+A simple changelog can be found on the [releases page](https://github.com/ttytm/wthrr-the-weathercrab/releases).
 
 ## Contributors
 
-<a href="https://github.com/tobealive/wthrr-the-weathercrab/graphs/contributors">
-  <img height='48' src="https://contrib.rocks/image?repo=tobealive/wthrr-the-weathercrab&columns=24" />
+<a href="https://github.com/ttytm/wthrr-the-weathercrab/graphs/contributors">
+  <img height='48' src="https://contrib.rocks/image?repo=ttytm/wthrr-the-weathercrab&columns=24" />
 </a>
 
 ## Credits


### PR DESCRIPTION
The PR updates the links in the docs and clarifies installation instructions.

The new step by step instructions aims to help users better understand the usage of required fonts.

It also moves the Arch linux installation instructions from the requirements to the installation section.