### PR TITLE
♻️ reduce dependencies for colorization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,17 +175,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
-name = "colored"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
-dependencies = [
- "is-terminal",
- "lazy_static",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "console"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,17 +568,6 @@ name = "ipnet"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
-dependencies = [
- "hermit-abi",
- "rustix",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "itoa"
@@ -1588,7 +1566,6 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
- "colored",
  "dialoguer",
  "directories",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ clap = { version = "4.4", default-features = false, features = [
 	"error-context",
 	"suggestions",
 ] }
-colored = "2.0"
 directories = "5.0"
 dialoguer = { version = "0.10", default-features = false }
 futures = "0.3"

--- a/src/modules/config.rs
+++ b/src/modules/config.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use colored::{Color::Yellow, Colorize};
+use dialoguer::console::style;
 use directories::ProjectDirs;
 use optional_struct::{optional_struct, Applyable};
 use ron::{
@@ -60,7 +60,7 @@ impl Config {
 			{
 				Ok(contents) => contents.apply_to(&mut config),
 				Err(error) => {
-					let warning_sign = " Warning:".color(Yellow);
+					let warning_sign = style(" Warning:").yellow();
 					eprintln!(
 						"{warning_sign} {}\n{: >4}At: {error}.\n{: >4}Falling back to default values.\n",
 						path.display(),

--- a/src/modules/display/current.rs
+++ b/src/modules/display/current.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
-use colored::{Color::BrightBlack, Colorize};
+use dialoguer::console::style;
 
 use crate::modules::{params::Params, units::Time};
 
 use super::{
 	border::{Border, BorderStyle, Edge, Separator},
-	gui_config::ColorOption,
+	gui_config::ConfigurableColor,
 	hourly::HourlyForecast,
 	product::{Product, MIN_CELL_WIDTH, MIN_WIDTH},
 	utils::lang_len_diff,
@@ -54,14 +54,14 @@ impl Current {
 		let (gui, lang) = (&params.config.gui, &params.config.language);
 
 		// Border Top
-		println!("{}", &Edge::Top.fmt(width, &gui.border).color_option(BrightBlack, &gui.color));
+		println!("{}", &Edge::Top.fmt(width, &gui.border).plain_or_bright_black(&gui.color));
 
 		// Address / Title
 		println!(
 			"{} {: ^width$} {}",
-			Border::L.fmt(&gui.border).color_option(BrightBlack, &gui.color),
-			address.bold(),
-			Border::R.fmt(&gui.border).color_option(BrightBlack, &gui.color),
+			Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color),
+			style(&address).bold(),
+			Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color),
 			width = width - 2 - lang_len_diff(&address, lang)
 		);
 
@@ -73,39 +73,36 @@ impl Current {
 				BorderStyle::solid => Separator::Solid.fmt(width, &gui.border),
 				_ => Separator::Single.fmt(width, &gui.border),
 			}
-			.color_option(BrightBlack, &gui.color)
+			.plain_or_bright_black(&gui.color),
 		);
 
 		// Temperature & Weathercode
 		println!(
 			"{} {: <width$} {}",
-			Border::L.fmt(&gui.border).color_option(BrightBlack, &gui.color),
-			(wmo_code.icon.to_string() + " " + &wmo_code.interpretation + ", " + &temperature).bold(),
-			Border::R.fmt(&gui.border).color_option(BrightBlack, &gui.color),
+			Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color),
+			style(wmo_code.icon.to_string() + " " + &wmo_code.interpretation + ", " + &temperature).bold(),
+			Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color),
 			width = width - 2 - lang_len_diff(&wmo_code.interpretation, lang)
 		);
 
 		// Apparent Temperature
 		println!(
 			"{} {: <width$} {}",
-			Border::L.fmt(&gui.border).color_option(BrightBlack, &gui.color),
+			Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color),
 			apparent_temperature,
-			Border::R.fmt(&gui.border).color_option(BrightBlack, &gui.color),
+			Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color),
 			width = width - 2 - lang_len_diff(&apparent_temperature, lang)
             // manually account for displacepment of this row until improving the lang_len_diff regex
             + if &lang[..2] == "ja" || &lang[..2] == "ko" { 2 } else { 0 }
 		);
 
 		// Blank Line
-		println!(
-			"{}",
-			Separator::Blank.fmt(width, &gui.border).color_option(BrightBlack, &gui.color)
-		);
+		println!("{}", Separator::Blank.fmt(width, &gui.border).plain_or_bright_black(&gui.color));
 
 		// Humidity & Dewpoint
 		println!(
 			"{} {: <width$} {}",
-			Border::L.fmt(&gui.border).color_option(BrightBlack, &gui.color),
+			Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color),
 			format!(
 				"{: <cell_width$} {}",
 				humidity,
@@ -114,7 +111,7 @@ impl Current {
 					- lang_len_diff(&humidity, lang)
 					- if &lang[..2] == "ja" || &lang[..2] == "ko" { 0 } else { 1 }
 			),
-			Border::R.fmt(&gui.border).color_option(BrightBlack, &gui.color),
+			Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color),
 			width = width - 2 - lang_len_diff(&humidity, lang) - lang_len_diff(&dewpoint, lang)
 				+ if &lang[..2] == "ja" || &lang[..2] == "ko" { 3 } else { 0 }
 		);
@@ -122,20 +119,20 @@ impl Current {
 		// Wind & Pressure
 		println!(
 			"{} {: <cell_width$}{: <width$} {}",
-			Border::L.fmt(&gui.border).color_option(BrightBlack, &gui.color),
+			Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color),
 			wind,
 			pressure,
-			Border::R.fmt(&gui.border).color_option(BrightBlack, &gui.color),
+			Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color),
 			width = width - 2 - cell_width
 		);
 
 		// Sunrise & Sunset
 		println!(
 			"{} {: <cell_width$}{: <width$} {}",
-			Border::L.fmt(&gui.border).color_option(BrightBlack, &gui.color),
+			Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color),
 			sunrise,
 			sunset,
-			Border::R.fmt(&gui.border).color_option(BrightBlack, &gui.color),
+			Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color),
 			width = width - 2 - cell_width
 		);
 
@@ -145,7 +142,7 @@ impl Current {
 		}
 
 		// Border Bottom
-		println!("{}", Edge::Bottom.fmt(width, &gui.border).color_option(BrightBlack, &gui.color));
+		println!("{}", Edge::Bottom.fmt(width, &gui.border).plain_or_bright_black(&gui.color));
 
 		dimensions
 	}

--- a/src/modules/display/day.rs
+++ b/src/modules/display/day.rs
@@ -1,12 +1,12 @@
 use anyhow::Result;
 use chrono::{Duration, Local};
-use colored::{Color::BrightBlack, Colorize};
+use dialoguer::console::style;
 
 use crate::modules::{display::hourly::WIDTH, localization::Locales, params::Params, units::Time};
 
 use super::{
 	border::{Border, BorderStyle, Edge, Separator},
-	gui_config::ColorOption,
+	gui_config::ConfigurableColor,
 	hourly::HourlyForecast,
 	product::Product,
 	utils::lang_len_diff,
@@ -42,14 +42,14 @@ impl Day {
 		let (gui, lang) = (&params.config.gui, &params.config.language);
 
 		// Border Top
-		println!("{}", &Edge::Top.fmt(WIDTH, &gui.border).color_option(BrightBlack, &gui.color));
+		println!("{}", &Edge::Top.fmt(WIDTH, &gui.border).plain_or_bright_black(&gui.color),);
 
 		// Address / Title
 		println!(
 			"{} {: ^WIDTH$} {}",
-			Border::L.fmt(&gui.border).color_option(BrightBlack, &gui.color),
-			address.bold(),
-			Border::R.fmt(&gui.border).color_option(BrightBlack, &gui.color),
+			Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color),
+			style(&address).bold(),
+			Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color),
 			WIDTH = WIDTH - 2 - lang_len_diff(&address, lang)
 		);
 
@@ -61,7 +61,7 @@ impl Day {
 				BorderStyle::solid => Separator::Solid.fmt(WIDTH, &gui.border),
 				_ => Separator::Single.fmt(WIDTH, &gui.border),
 			}
-			.color_option(BrightBlack, &gui.color)
+			.plain_or_bright_black(&gui.color),
 		);
 
 		// Temperature & Weathercode
@@ -71,10 +71,10 @@ impl Day {
 		);
 		println!(
 			"{} {} {: >WIDTH$} {}",
-			Border::L.fmt(&gui.border).color_option(BrightBlack, &gui.color),
-			temperature_and_weathercode.bold(),
+			Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color),
+			style(&temperature_and_weathercode).bold(),
 			date,
-			Border::R.fmt(&gui.border).color_option(BrightBlack, &gui.color),
+			Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color),
 			WIDTH = WIDTH
 				- 3 - lang_len_diff(&wmo_code.interpretation, lang)
 				- temperature_and_weathercode.chars().count()
@@ -85,10 +85,10 @@ impl Day {
 		let sunrise_and_sunset = format!("{sunrise}  {sunset}");
 		println!(
 			"{} {} {: >WIDTH$} {}",
-			Border::L.fmt(&gui.border).color_option(BrightBlack, &gui.color),
+			Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color),
 			apparent_temp_max_min,
 			sunrise_and_sunset,
-			Border::R.fmt(&gui.border).color_option(BrightBlack, &gui.color),
+			Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color),
 			WIDTH = WIDTH
 				- 3 - lang_len_diff(&params.texts.weather.feels_like, lang)
 				- apparent_temp_max_min.chars().count()
@@ -98,7 +98,7 @@ impl Day {
 		hourly_forecast.render(params);
 
 		// Border Bottom
-		println!("{}", Edge::Bottom.fmt(WIDTH, &gui.border).color_option(BrightBlack, &gui.color));
+		println!("{}", Edge::Bottom.fmt(WIDTH, &gui.border).plain_or_bright_black(&gui.color),);
 	}
 
 	pub fn prep(product: &Product, params: &Params, day_index: usize) -> Result<Self> {

--- a/src/modules/display/gui_config.rs
+++ b/src/modules/display/gui_config.rs
@@ -1,4 +1,4 @@
-use colored::{Color, ColoredString, Colorize};
+use dialoguer::console::{style, StyledObject};
 use optional_struct::{optional_struct, Applyable};
 use serde::{Deserialize, Serialize};
 
@@ -36,15 +36,29 @@ impl Default for Gui {
 	}
 }
 
-pub trait ColorOption {
-	fn color_option(self, default_color: Color, config_color: &ColorVariant) -> ColoredString;
+pub trait ConfigurableColor<'a> {
+	fn plain_or_bright_black(self, config_color: &ColorVariant) -> StyledObject<&'a str>;
+	fn plain_or_yellow(self, config_color: &ColorVariant) -> StyledObject<&'a str>;
+	fn plain_or_blue(self, config_color: &ColorVariant) -> StyledObject<&'a str>;
 }
 
-impl<'a> ColorOption for &'a str {
-	fn color_option(self, default_color: Color, config_color: &ColorVariant) -> ColoredString {
+impl<'a> ConfigurableColor<'a> for &'a str {
+	fn plain_or_bright_black(self, config_color: &ColorVariant) -> StyledObject<&'a str> {
 		match config_color {
-			ColorVariant::plain => self.normal(),
-			ColorVariant::default => self.color(default_color),
+			ColorVariant::plain => style(self),
+			ColorVariant::default => style(self).black().bright(),
+		}
+	}
+	fn plain_or_yellow(self, config_color: &ColorVariant) -> StyledObject<&'a str> {
+		match config_color {
+			ColorVariant::plain => style(self),
+			ColorVariant::default => style(self).yellow(),
+		}
+	}
+	fn plain_or_blue(self, config_color: &ColorVariant) -> StyledObject<&'a str> {
+		match config_color {
+			ColorVariant::plain => style(self),
+			ColorVariant::default => style(self).blue(),
 		}
 	}
 }

--- a/src/modules/display/historical.rs
+++ b/src/modules/display/historical.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use chrono::NaiveDate;
-use colored::{Color::BrightBlack, Colorize};
+use dialoguer::console::style;
 
 use crate::modules::{
 	config::Config,
@@ -12,7 +12,7 @@ use crate::modules::{
 
 use super::{
 	border::{Border, BorderStyle, Edge, Separator},
-	gui_config::ColorOption,
+	gui_config::ConfigurableColor,
 	hourly::HourlyForecast,
 	product::Product,
 	utils::lang_len_diff,
@@ -48,14 +48,14 @@ impl HistoricalWeather {
 		let (gui, lang) = (&params.config.gui, &params.config.language);
 
 		// Border Top
-		println!("{}", &Edge::Top.fmt(WIDTH, &gui.border).color_option(BrightBlack, &gui.color));
+		println!("{}", &Edge::Top.fmt(WIDTH, &gui.border).plain_or_bright_black(&gui.color));
 
 		// Address / Title
 		println!(
 			"{} {: ^WIDTH$} {}",
-			Border::L.fmt(&gui.border).color_option(BrightBlack, &gui.color),
-			address.bold(),
-			Border::R.fmt(&gui.border).color_option(BrightBlack, &gui.color),
+			Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color),
+			style(&address).bold(),
+			Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color),
 			WIDTH = WIDTH - 2 - lang_len_diff(&address, lang)
 		);
 
@@ -67,7 +67,7 @@ impl HistoricalWeather {
 				BorderStyle::solid => Separator::Solid.fmt(WIDTH, &gui.border),
 				_ => Separator::Single.fmt(WIDTH, &gui.border),
 			}
-			.color_option(BrightBlack, &gui.color)
+			.plain_or_bright_black(&gui.color)
 		);
 
 		// Temperature & Weathercode
@@ -77,10 +77,10 @@ impl HistoricalWeather {
 		);
 		println!(
 			"{} {} {: >WIDTH$} {}",
-			Border::L.fmt(&gui.border).color_option(BrightBlack, &gui.color),
-			temperature_and_weathercode.bold(),
+			Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color),
+			style(&temperature_and_weathercode).bold(),
 			date,
-			Border::R.fmt(&gui.border).color_option(BrightBlack, &gui.color),
+			Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color),
 			WIDTH = WIDTH
 				- 3 - lang_len_diff(&wmo_code.interpretation, lang)
 				- temperature_and_weathercode.chars().count()
@@ -91,10 +91,10 @@ impl HistoricalWeather {
 		let sunrise_and_sunset = format!("{sunrise}  {sunset}");
 		println!(
 			"{} {} {: >WIDTH$} {}",
-			Border::L.fmt(&gui.border).color_option(BrightBlack, &gui.color),
+			Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color),
 			apparent_temp_max_min,
 			sunrise_and_sunset,
-			Border::R.fmt(&gui.border).color_option(BrightBlack, &gui.color),
+			Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color),
 			WIDTH = WIDTH
 				- 3 - lang_len_diff(&params.texts.weather.felt_like, lang)
 				- apparent_temp_max_min.chars().count()
@@ -122,7 +122,7 @@ impl HistoricalWeather {
 		hourly_forecast.render(&params);
 
 		// Border Bottom
-		println!("{}", Edge::Bottom.fmt(WIDTH, &gui.border).color_option(BrightBlack, &gui.color));
+		println!("{}", Edge::Bottom.fmt(WIDTH, &gui.border).plain_or_bright_black(&gui.color));
 	}
 
 	pub fn prep(product: &Product, params: &Params, date: &NaiveDate) -> Result<Self> {

--- a/src/modules/display/hourly.rs
+++ b/src/modules/display/hourly.rs
@@ -1,9 +1,6 @@
 use anyhow::Result;
 use chrono::{Timelike, Utc};
-use colored::{
-	Color::{Blue, BrightBlack, Yellow},
-	Colorize,
-};
+use dialoguer::console::style;
 use std::fmt::Write as _;
 
 use crate::modules::{
@@ -16,7 +13,7 @@ use crate::modules::{
 use super::{
 	border::{Border, BorderStyle, Separator},
 	graph::Graph,
-	gui_config::ColorOption,
+	gui_config::ConfigurableColor,
 	product::Product,
 	utils::{lang_len_diff, style_number},
 	weathercode::WeatherCode,
@@ -55,7 +52,7 @@ impl HourlyForecast {
 		// Blank Line
 		println!(
 			"{}",
-			&Separator::Blank.fmt(WIDTH, &gui.border).color_option(BrightBlack, &gui.color)
+			&Separator::Blank.fmt(WIDTH, &gui.border).plain_or_bright_black(&gui.color),
 		);
 
 		// Set Measurement Unit Symbols
@@ -72,9 +69,9 @@ impl HourlyForecast {
 		// Hourly Forecast Heading
 		println!(
 			"{} {: <WIDTH$} {}",
-			Border::L.fmt(&gui.border).color_option(BrightBlack, &gui.color),
-			heading.bold(),
-			Border::R.fmt(&gui.border).color_option(BrightBlack, &gui.color),
+			Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color),
+			style(&heading).bold(),
+			Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color),
 			WIDTH = WIDTH - 2 - lang_len_diff(&heading, &params.config.language)
 		);
 
@@ -82,12 +79,12 @@ impl HourlyForecast {
 		if let Some(summary) = summary {
 			println!(
 				"{} {} ❲{}{}❳{: <WIDTH$} {}",
-				Border::L.fmt(&gui.border).color_option(BrightBlack, &gui.color),
+				Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color),
 				summary.temp_max_min,
 				summary.precipitation_probability_max,
-				"󰖎".bold(),
+				style("󰖎").bold(),
 				"",
-				Border::R.fmt(&gui.border).color_option(BrightBlack, &gui.color),
+				Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color),
 				WIDTH =
 					WIDTH - 5 - summary.temp_max_min.len() - summary.precipitation_probability_max.to_string().len()
 			);
@@ -98,13 +95,13 @@ impl HourlyForecast {
 			Some(col) => {
 				println!(
 					"{}",
-					Self::prepare_separator(col, &gui.border, WIDTH, '╤').color_option(BrightBlack, &gui.color),
+					Self::prepare_separator(col, &gui.border, WIDTH, '╤').plain_or_bright_black(&gui.color)
 				);
 			}
 			_ => {
 				println!(
 					"{}",
-					Separator::Dashed.fmt(WIDTH, &gui.border).color_option(BrightBlack, &gui.color)
+					Separator::Dashed.fmt(WIDTH, &gui.border).plain_or_bright_black(&gui.color),
 				);
 			}
 		}
@@ -112,48 +109,48 @@ impl HourlyForecast {
 		// Temperatures
 		println!(
 			"{} {: <WIDTH$}{} {}",
-			Border::L.fmt(&gui.border).color_option(BrightBlack, &gui.color),
-			temperatures.color_option(Yellow, &gui.color).bold(),
-			temperature_unit.color_option(Yellow, &gui.color).bold(),
-			Border::R.fmt(&gui.border).color_option(BrightBlack, &gui.color),
+			Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color),
+			temperatures.plain_or_yellow(&gui.color).bold(),
+			temperature_unit.plain_or_yellow(&gui.color).bold(),
+			Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color),
 			WIDTH = WIDTH - 3
 		);
 
 		// Blank Line
 		println!(
 			"{}",
-			&Separator::Blank.fmt(WIDTH, &gui.border).color_option(BrightBlack, &gui.color)
+			&Separator::Blank.fmt(WIDTH, &gui.border).plain_or_bright_black(&gui.color)
 		);
 
 		// Graph Row 1
 		if graph.1.chars().count() > 0 {
 			println!(
 				"{}{}{}",
-				Border::L.fmt(&gui.border).color_option(BrightBlack, &gui.color),
-				graph.1.color_option(Yellow, &gui.color),
-				Border::R.fmt(&gui.border).color_option(BrightBlack, &gui.color)
+				Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color),
+				graph.1.plain_or_yellow(&gui.color),
+				Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color),
 			);
 		}
 		// Graph Row 2
 		println!(
 			"{}{}{}",
-			Border::L.fmt(&gui.border).color_option(BrightBlack, &gui.color),
-			graph.0.color_option(Yellow, &gui.color),
-			Border::R.fmt(&gui.border).color_option(BrightBlack, &gui.color)
+			Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color),
+			graph.0.plain_or_yellow(&gui.color),
+			Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color),
 		);
 
 		// Precipitation
 		println!(
 			"{} {: <WIDTH$}{}{}",
-			Border::L.fmt(&gui.border).color_option(BrightBlack, &gui.color),
-			precipitation.color_option(Blue, &gui.color).bold(),
+			Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color),
+			precipitation.plain_or_blue(&gui.color).bold(),
 			if units.precipitation == Precipitation::probability {
 				// to enlarge the water percent icon we use bold as a hack
-				precipitation_unit.color_option(Blue, &gui.color).bold()
+				precipitation_unit.plain_or_blue(&gui.color).bold()
 			} else {
-				precipitation_unit.color_option(Blue, &gui.color)
+				precipitation_unit.plain_or_blue(&gui.color)
 			},
-			Border::R.fmt(&gui.border).color_option(BrightBlack, &gui.color),
+			Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color),
 			WIDTH = WIDTH - 1 - precipitation_unit.chars().count()
 		);
 
@@ -162,19 +159,19 @@ impl HourlyForecast {
 			Some(col) => {
 				println!(
 					"{}",
-					Self::prepare_separator(col, &gui.border, WIDTH, '╧').color_option(BrightBlack, &gui.color),
+					Self::prepare_separator(col, &gui.border, WIDTH, '╧').plain_or_bright_black(&gui.color),
 				);
 			}
 			_ => {
 				println!(
 					"{}",
-					Separator::Dashed.fmt(WIDTH, &gui.border).color_option(BrightBlack, &gui.color)
+					Separator::Dashed.fmt(WIDTH, &gui.border).plain_or_bright_black(&gui.color),
 				);
 			}
 		}
 
 		// Graph Hours Row
-		print!("{}", Border::L.fmt(&gui.border).color_option(BrightBlack, &gui.color));
+		print!("{}", Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color));
 		let hours = match units.time {
 			Time::am_pm => ["¹²·⁰⁰ₐₘ", "³·⁰⁰ₐₘ", "⁶˙⁰⁰ₐₘ", "⁹˙⁰⁰ₐₘ", "¹²˙⁰⁰ₚₘ", "³˙⁰⁰ₚₘ", "⁶˙⁰⁰ₚₘ", "⁹˙⁰⁰ₚₘ"],
 			Time::military => ["⁰⁰˙⁰⁰", "⁰³˙⁰⁰", "⁰⁶˙⁰⁰", "⁰⁹˙⁰⁰", "¹²˙⁰⁰", "¹⁵˙⁰⁰", "¹⁸˙⁰⁰", "²¹˙⁰⁰"],
@@ -182,7 +179,7 @@ impl HourlyForecast {
 		for hour in hours {
 			print!("{hour: <9}");
 		}
-		println!("{}", Border::R.fmt(&gui.border).color_option(BrightBlack, &gui.color));
+		println!("{}", Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color));
 	}
 
 	pub fn prepare(product: &Product, params: &Params, day_index: usize) -> Result<Self> {

--- a/src/modules/display/product.rs
+++ b/src/modules/display/product.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use chrono::NaiveDate;
-use colored::Color::BrightBlack;
 use scopeguard::defer;
 use std::collections::HashMap;
 
@@ -10,7 +9,7 @@ use crate::modules::{
 	weather::{OptionalWeather, Weather},
 };
 
-use super::{current::Current, day::Day, gui_config::ColorOption, historical::HistoricalWeather, week::Week};
+use super::{current::Current, day::Day, gui_config::ConfigurableColor, historical::HistoricalWeather, week::Week};
 
 pub struct Product<'a> {
 	pub address: String,
@@ -25,7 +24,7 @@ impl Product<'_> {
 	pub fn render(&self, params: &Params) -> Result<()> {
 		defer! {
 			// Disclaimer
-			println!(" {}", "Weather data by Open-Meteo.com\n".color_option(BrightBlack, &params.config.gui.color));
+			println!(" {}", "Weather data by Open-Meteo.com\n".plain_or_bright_black(&params.config.gui.color))
 		}
 
 		if params.config.forecast.is_empty() && params.historical_weather.is_empty() {

--- a/src/modules/display/week.rs
+++ b/src/modules/display/week.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use chrono::NaiveDate;
-use colored::Color::BrightBlack;
 use serde::{Deserialize, Serialize};
 
 use crate::modules::{localization::Locales, params::Params};
@@ -8,7 +7,7 @@ use crate::modules::{localization::Locales, params::Params};
 use super::{
 	border::{Border, BorderStyle, Edge, Separator},
 	current::Dimensions,
-	gui_config::ColorOption,
+	gui_config::ConfigurableColor,
 	product::{Product, MIN_CELL_WIDTH},
 	utils::lang_len_diff,
 	weathercode::WeatherCode,
@@ -39,7 +38,7 @@ impl Week {
 		}
 
 		// Border Top
-		println!("{}", &Edge::Top.fmt(width, &gui.border).color_option(BrightBlack, &gui.color));
+		println!("{}", &Edge::Top.fmt(width, &gui.border).plain_or_bright_black(&gui.color));
 
 		let mut chunks = forecast.days.chunks(1).peekable();
 
@@ -67,9 +66,9 @@ impl Week {
 			);
 			println!(
 				"{} {: <width$} {}",
-				&Border::L.fmt(&gui.border).color_option(BrightBlack, &gui.color),
+				&Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color),
 				forecast_day,
-				&Border::R.fmt(&gui.border).color_option(BrightBlack, &gui.color),
+				&Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color),
 				width = width
 					- lang_len_diff(&forecast.days[n].interpretation, lang)
 					- lang_len_diff(&forecast.days[n].date, lang)
@@ -83,7 +82,7 @@ impl Week {
 						BorderStyle::solid => Separator::Solid.fmt(width, &gui.border),
 						_ => Separator::Dashed.fmt(width, &gui.border),
 					}
-					.color_option(BrightBlack, &gui.color)
+					.plain_or_bright_black(&gui.color)
 				);
 			}
 
@@ -91,7 +90,7 @@ impl Week {
 		}
 
 		// Border Bottom
-		println!("{}", Edge::Bottom.fmt(width, &gui.border).color_option(BrightBlack, &gui.color));
+		println!("{}", Edge::Bottom.fmt(width, &gui.border).plain_or_bright_black(&gui.color));
 	}
 
 	pub fn prep(product: &Product, params: &Params) -> Result<Self> {


### PR DESCRIPTION
Moves towards using the `console` crate for colorization. It is also used by the `dialoguer` crate, which is used for the dialogs.