### PR TITLE
🤖 add linting Action for Renovate configuration

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,3 +41,11 @@ jobs:
       - uses: docker://rhysd/actionlint:latest
         with:
           args: -color
+
+  renovate-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: suzuki-shunsuke/github-action-renovate-config-validator@v0.1.3


### PR DESCRIPTION
As announced, this PR introduces a GHA to lint the Renovate configuration.  Changes to the Renovate setup will be submitted in a subsequent, separate PR.  The Action should succeed within usually 40 seconds.