### PR TITLE
🤖 Renovate Schedule Fine-tuning

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -18,7 +18,6 @@
     commitMessageAction: "maintain Cargo.lock",
     commitMessagePrefix: "🤖",
     enabled: true,
-    schedule: "* 0 * * MON",
   },
   packageRules: [
     {

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -37,5 +37,5 @@
       ],
     },
   ],
-  schedule: "* 0 * * MON",
+  schedule: "before 4am on monday",
 }


### PR DESCRIPTION
This PR adjusts the schedules of Renovate's update cycles.

- By default (i.e., if there is no schedule defined), Renovate will run a Lock File Maintenance always "before 4am on monday".  I experienced this being somehow more reliable than my previous Cron setup.  Thus, I removed the explicit Cron schedule to rely on the implicit default.
- I set the implicit default of the Lock File Maintenance as the explicit value of the general schedule.  All updates, including Lock File Maintenances, should be in sync, now.