### PR TITLE
🤖 Renovate:  disable hourly PR creation limit

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -37,5 +37,6 @@
       ],
     },
   ],
+  prHourlyLimit: null,
   schedule: "before 4am on monday",
 }


### PR DESCRIPTION
This PR removes the default hourly limit of at most two PRs being created per hour.  Removing this restriction will benefit the weekly auto-maintenance run.