### PR TITLE
🤖 add debounce step to skip obsolete runs on the origin repo in case there is a PR and a push to a branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
 
   Lint:
     needs: debounce
+    if: needs.debounce.outputs.abort != 'true'
     uses: ./.github/workflows/lint.yml
 
   Test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
         if: github.ref_name != 'main' && github.event_name == 'push'
         id: debounce
         run: |
-          pr_branches=$(gh pr list --json headRefName --repo $GITHUB_REPOSITORY)
-          if [[ "$pr_branches" != '[]' && $(echo "$pr_branches" | jq -r --arg GITHUB_REF_NAME '.[].headRefName | select(. == $GITHUB_REF_NAME)') ]]; then
+          pr_branches="$(gh pr list --json headRefName --repo $GITHUB_REPOSITORY)"
+          if [[ "$pr_branches" != '[]' && "$(echo "$pr_branches" | jq -r --arg GITHUB_REF_NAME '.[].headRefName | select(. == $GITHUB_REF_NAME)')" ]]; then
             echo "This push is associated with a pull request. Skipping the job."
             echo "abort=true" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
         if: github.ref_name != 'main' && github.event_name == 'push'
         id: debounce
         run: |
-          pr_branches="$(gh pr list --json headRefName --repo $GITHUB_REPOSITORY)"
-          if [[ "$pr_branches" != '[]' && "$(echo "$pr_branches" | jq -r --arg GITHUB_REF_NAME '.[].headRefName | select(. == $GITHUB_REF_NAME)')" ]]; then
+          pr_branches=$(gh pr list --json headRefName --repo "$GITHUB_REPOSITORY")
+          if [[ "$pr_branches" != '[]' && $(echo "$pr_branches" | jq -r --arg GITHUB_REF_NAME '.[].headRefName | select(. == "$GITHUB_REF_NAME")') ]]; then
             echo "This push is associated with a pull request. Skipping the job."
             echo "abort=true" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,25 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  debounce:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    outputs:
+      abort: ${{ steps.debounce.outputs.abort }}
+    steps:
+      - name: Debounce
+        if: github.ref_name != 'main' && github.event_name == 'push'
+        id: debounce
+        run: |
+          pr_branches=$(gh pr list --json headRefName --repo $GITHUB_REPOSITORY)
+          if [[ "$pr_branches" != '[]' && $(echo "$pr_branches" | jq -r --arg GITHUB_REF_NAME '.[].headRefName | select(. == $GITHUB_REF_NAME)') ]]; then
+            echo "This push is associated with a pull request. Skipping the job."
+            echo "abort=true" >> "$GITHUB_OUTPUT"
+          fi
+
   Lint:
+    needs: debounce
     uses: ./.github/workflows/lint.yml
 
   Test:


### PR DESCRIPTION
This will skip redundant runs in case there is a push to a branch on the origin repo that also has a PR associated with it.