### PR TITLE
🤖 add debounce step to skip redundant runs on the origin repo (#319)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
           mkdir -p test-results
           mv target/nextest/ci/junit-*.xml test-results/
       - name: Upload test results
+        if: runner.os == 'Linux'
         uses: actions/upload-artifact@v3
         with:
           name: test-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,26 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  debounce:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    outputs:
+      abort: ${{ steps.debounce.outputs.abort }}
+    steps:
+      - name: Debounce
+        if: github.ref_name != 'main' && github.event_name == 'push'
+        id: debounce
+        run: |
+          pr_branches=$(gh pr list --json headRefName --repo "$GITHUB_REPOSITORY")
+          if [[ "$pr_branches" != '[]' && $(echo "$pr_branches" | jq -r --arg GITHUB_REF_NAME '.[].headRefName | select(. == "$GITHUB_REF_NAME")') ]]; then
+            echo "This push is associated with a pull request. Skipping the job."
+            echo "abort=true" >> "$GITHUB_OUTPUT"
+          fi
+
   Lint:
+    needs: debounce
+    if: needs.debounce.outputs.abort != 'true'
     uses: ./.github/workflows/lint.yml
 
   Test:


### PR DESCRIPTION
Local repro help for potential future reference:

```sh
pr_branches=$(gh pr list --json headRefName --repo "ttytm/wthrr-the-weathercrab")
echo "pr_branches=$pr_branches"
echo "GITHUB_REF_NAME=$GITHUB_REF_NAME"

# GITHUB_REF_NAME="ci/upload-test-results-only-once" # no PR, should not abort
GITHUB_REF_NAME="renovate/actions-upload-artifact-4.x" # a branch with a PR assiciated, should abort
if [[ $(echo "$(gh pr list --json headRefName --repo "tobealive/wthrr-the-weathercrab")" | jq -r --arg ref_name "$GITHUB_REF_NAME" '.[] | select(.headRefName == $ref_name)') ]]; then
	echo "This push is associated with a pull request. Skipping the job."
	# echo "abort=true" >> "$GITHUB_OUTPUT"
	echo "abort=true"
fi
```