### PR TITLE
🤖 refine debounce

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
           pr_branches=$(gh pr list --json headRefName --repo "$GITHUB_REPOSITORY")
           echo "pr_branches=$pr_branches"
           echo "GITHUB_REF_NAME=$GITHUB_REF_NAME"
-          if [[ $(echo "$(gh pr list --json headRefName --repo "tobealive/wthrr-the-weathercrab")" | jq -r --arg ref_name "$GITHUB_REF_NAME" '.[] | select(.headRefName == $ref_name)') ]]; then
-            echo "This push is associated with a pull request. Skipping the job."
+          if [[ $(echo "$pr_branches" | jq -r --arg ref_name "$GITHUB_REF_NAME" '.[] | select(.headRefName == $ref_name)') ]]; then
+            echo "Push to branch that is associated with a pull request. Skipping redundant the job."
             echo "abort=true" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     outputs:
-      abort: ${{ steps.debounce.outputs.abort }}
+      skip: ${{ steps.debounce.outputs.skip }}
     steps:
       - name: Debounce
         if: github.ref_name != 'main' && github.event_name == 'push'
@@ -30,13 +30,13 @@ jobs:
           echo "pr_branches=$pr_branches"
           echo "GITHUB_REF_NAME=$GITHUB_REF_NAME"
           if [[ $(echo "$pr_branches" | jq -r --arg ref_name "$GITHUB_REF_NAME" '.[] | select(.headRefName == $ref_name)') ]]; then
-            echo "Push to branch that is associated with a pull request. Skipping redundant the job."
-            echo "abort=true" >> "$GITHUB_OUTPUT"
+            echo "Push to a branch that is associated with a pull request. Skipping redundant job."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
 
   Lint:
     needs: debounce
-    if: needs.debounce.outputs.abort != 'true'
+    if: needs.debounce.outputs.skip != 'true'
     uses: ./.github/workflows/lint.yml
 
   Test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,9 @@ jobs:
         id: debounce
         run: |
           pr_branches=$(gh pr list --json headRefName --repo "$GITHUB_REPOSITORY")
-          if [[ "$pr_branches" != '[]' && $(echo "$pr_branches" | jq -r --arg GITHUB_REF_NAME '.[].headRefName | select(. == "$GITHUB_REF_NAME")') ]]; then
+          echo "pr_branches=$pr_branches"
+          echo "GITHUB_REF_NAME=$GITHUB_REF_NAME"
+          if [[ $(echo "$(gh pr list --json headRefName --repo "tobealive/wthrr-the-weathercrab")" | jq -r --arg ref_name "$GITHUB_REF_NAME" '.[] | select(.headRefName == $ref_name)') ]]; then
             echo "This push is associated with a pull request. Skipping the job."
             echo "abort=true" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
Quick snip for a local repro help for potential future reference:

```sh
GITHUB_REPOSITORY="ttytm/wthrr-the-weathercrab"
# GITHUB_REF_NAME="ci/upload-test-results-only-once" # no PR, should not abort
GITHUB_REF_NAME="renovate/actions-upload-artifact-4.x" # a branch with a PR assiciated, should abort

pr_branches=$(gh pr list --json headRefName --repo "$GITHUB_REPOSITORY")
echo "pr_branches=$pr_branches"
echo "GITHUB_REF_NAME=$GITHUB_REF_NAME"

if [[ $(echo "$pr_branches" | jq -r --arg ref_name "$GITHUB_REF_NAME" '.[] | select(.headRefName == $ref_name)') ]]; then
	echo "This push is associated with a pull request. Skipping the job."
	echo "abort=true" >> "$GITHUB_OUTPUT"
fi
```