### PR TITLE
🤖 refine release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-11, macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name == 'main' && github.sha || github.ref }}
   cancel-in-progress: true
 
-env:
-  CARGO_TERM_COLOR: always
-
 jobs:
   Debounce:
     runs-on: ubuntu-latest
@@ -62,6 +59,7 @@ jobs:
       - name: Run test
         env:
           RUST_BACKTRACE: full
+          CARGO_TERM_COLOR: always
         run: |
           cargo nextest run --verbose --profile ci
           mv target/nextest/ci/junit.xml target/nextest/ci/junit-${{ matrix.os }}.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-13, macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-11, macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        # Should not be required, though `cargo: command not found` [2024/06/12]
-        if: ${{ matrix.os == 'macos-13' }}
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-13, macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        # Should not be required, though `cargo: command not found` [2024/06/12]
+        if: ${{ matrix.os == 'macos-13' }}
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,7 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           files: 'target/nextest/ci/junit*.xml'
+
+  Release:
+    needs: Test
+    uses: ./.github/workflows/release.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
             mv "./target/release/wthrr.exe" "./$artifact/"
           elif [[ $RUNNER_OS == "Linux" ]]; then
             mv "./target/release/wthrr" "./$artifact/"
-            mv ./wthrr-*-x86_64.AppImage "./artifacts/"
+            mv ./wthrr.AppImage "./artifacts/$artifact.AppImage"
           fi
           tar -czf "./artifacts/$artifact.tar.gz" "$artifact"
       - name: Archive artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,16 +20,13 @@ jobs:
           - os: windows-latest
             target: x86_64-windows
             # Apple targets are not properly signed. Users will have to mark the binaries as secure manually.
-          - os: macos-13
+          - os: macos-11
             target: x86_64-apple-darwin
           - os: macos-latest
             target: arm64-apple-darwin
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        # Should not be required, though `cargo: command not found` [2024/06/12]
-        if: ${{ matrix.os == 'macos-13' }}
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,23 +52,24 @@ jobs:
           fi
       - name: Prepare artifacts
         run: |
-          mkdir -p ./artifacts
+          mkdir "${{ matrix.target }}"
           version="$GITHUB_REF_NAME"
           artifact="wthrr-$version-${{ matrix.target }}"
-          mkdir "$artifact"
-          cp README.md LICENSE "$artifact/"
+          cp README.md LICENSE "${{ matrix.target }}/"
           if [[ $RUNNER_OS == "Windows" ]]; then
-            mv "./target/release/wthrr.exe" "./$artifact/"
-          elif [[ $RUNNER_OS == "Linux" ]]; then
-            mv "./target/release/wthrr" "./$artifact/"
-            mv ./wthrr.AppImage "./artifacts/$artifact.AppImage"
+            mv "./target/release/wthrr.exe" "./${{ matrix.target }}/"
+          else
+            mv "./target/release/wthrr" "./${{ matrix.target }}/"
           fi
-          tar -czf "./artifacts/$artifact.tar.gz" "$artifact"
+          if [[ $RUNNER_OS == "Linux" ]]; then
+            mv ./wthrr.AppImage "./${{ matrix.target }}/$artifact.AppImage"
+          fi
+          echo "ARTIFACT=$artifact" >> "$GITHUB_ENV"
       - name: Archive artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: result
-          path: ./artifacts
+          name: ${{ env.ARTIFACT }}
+          path: ${{ matrix.target }}/**
 
   deploy:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           - os: windows-latest
             target: x86_64-windows
             # Apple targets are not properly signed. Users will have to mark the binaries as secure manually.
-          - os: macos-13
+          - os: macos-11
             target: x86_64-apple-darwin
           - os: macos-latest
             target: arm64-apple-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           if [[ $RUNNER_OS == "Windows" ]]; then
             binary+=.exe
           elif [[ $RUNNER_OS == "Linux" ]]; then
-            mv ./wthrr.AppImage "./${{ matrix.target }}/$artifact.AppImage"
+            mv ./target/appimage/wthrr.AppImage "./${{ matrix.target }}/"
           fi
           mv "./target/release/$binary" "./${{ matrix.target }}/"
           cp README.md LICENSE "${{ matrix.target }}/"
@@ -83,7 +83,7 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          files: ./artifacts/*.tar.gz, ./artifacts/*.AppImage
+          files: ./artifacts/wthrr*
 
   publish:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,43 +62,16 @@ jobs:
           cp README.md LICENSE "${{ matrix.target }}/"
           [[ $RUNNER_OS == "tag" ]] && version="$GITHUB_REF" || version="$GITHUB_SHA"
           echo "ARTIFACT=wthrr-$version-${{ matrix.target }}" >> "$GITHUB_ENV"
-      - name: Archive artifacts
+      - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ARTIFACT }}
           path: ${{ matrix.target }}/**
-
-  deploy:
-    needs: build
-    if: github.ref_name == 'main' && github.ref_type == 'tag'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: result
-          path: ./artifacts
-      - name: List
-        run: find ./artifacts
       - name: Release
+        if: github.ref_name == 'main' && github.ref_type == 'tag'
         uses: softprops/action-gh-release@v2
         with:
           files: ./artifacts/wthrr*
-
-  publish:
-    needs: build
-    if: github.ref_name == 'main' && github.ref_type == 'tag'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Publish
+      - name: Publish on crates.io
+        if: github.ref_name == 'main' && github.ref_type == 'tag'
         run: cargo publish --token ${{ secrets.CRATES_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           - os: windows-latest
             target: x86_64-windows
             # Apple targets are not properly signed. Users will have to mark the binaries as secure manually.
-          - os: macos-12
+          - os: macos-13
             target: x86_64-apple-darwin
           - os: macos-latest
             target: arm64-apple-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,16 @@ jobs:
           - os: windows-latest
             target: x86_64-windows
             # Apple targets are not properly signed. Users will have to mark the binaries as secure manually.
-          - os: macos-11
+          - os: macos-13
             target: x86_64-apple-darwin
           - os: macos-latest
             target: arm64-apple-darwin
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        # Should not be required, though `cargo: command not found` [2024/06/12]
+        if: ${{ matrix.os == 'macos-13' }}
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,18 +52,16 @@ jobs:
       - name: Prepare artifacts
         run: |
           mkdir "${{ matrix.target }}"
-          version="$GITHUB_REF_NAME"
-          artifact="wthrr-$version-${{ matrix.target }}"
-          cp README.md LICENSE "${{ matrix.target }}/"
+          binary=wthrr
           if [[ $RUNNER_OS == "Windows" ]]; then
-            mv "./target/release/wthrr.exe" "./${{ matrix.target }}/"
-          else
-            mv "./target/release/wthrr" "./${{ matrix.target }}/"
-          fi
-          if [[ $RUNNER_OS == "Linux" ]]; then
+            binary+=.exe
+          elif [[ $RUNNER_OS == "Linux" ]]; then
             mv ./wthrr.AppImage "./${{ matrix.target }}/$artifact.AppImage"
           fi
-          echo "ARTIFACT=$artifact" >> "$GITHUB_ENV"
+          mv "./target/release/$binary" "./${{ matrix.target }}/"
+          cp README.md LICENSE "${{ matrix.target }}/"
+          [[ $RUNNER_OS == "tag" ]] && version="$GITHUB_REF" || version="$GITHUB_SHA"
+          echo "ARTIFACT=wthrr-$version-${{ matrix.target }}" >> "$GITHUB_ENV"
       - name: Archive artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,11 @@ name: Release
 on:
   workflow_call:
 
-env:
-  CARGO_TERM_COLOR: always
-
 defaults:
   run:
     shell: bash # Convenience workaround for Windows.
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
 name: Release
 
 on:
-  workflow_run:
-    workflows: ['CI']
-    types: [completed]
+  workflow_call:
 
 env:
   CARGO_TERM_COLOR: always
@@ -14,7 +12,6 @@ defaults:
 
 jobs:
   build:
-    if: github.event.workflow_run.conclusion == 'success'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Simplifies the workflow and serves as preparation for further extensions, like including a .deb artifact