### PR TITLE
🤖 update artifact names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,14 +16,14 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            target: x86_64-linux
+            target: linux-x86_64
           - os: windows-latest
-            target: x86_64-windows
+            target: windows-x86_64
             # Apple targets are not properly signed. Users will have to mark the binaries as secure manually.
           - os: macos-11
-            target: x86_64-apple-darwin
+            target: macos-x86_64
           - os: macos-latest
-            target: arm64-apple-darwin
+            target: macos-arm64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -62,7 +62,6 @@ jobs:
             mv ./target/debian/wthrr*.deb "./${{ matrix.target }}/wthrr.deb"
           fi
           mv "./target/release/$binary" "./${{ matrix.target }}/"
-          cp README.md LICENSE "${{ matrix.target }}/"
           [[ $RUNNER_OS == "tag" ]] && version="$GITHUB_REF" || version="$GITHUB_SHA"
           echo "ARTIFACT=wthrr-$version-${{ matrix.target }}" >> "$GITHUB_ENV"
       - name: Upload artifacts


### PR DESCRIPTION
Updates release artifacts from e.g.:

- `wthrr-v1.1.1-x86_64-linux.tar.gz` to `wthrr-linux-x86_64`
- `wthrr-v1.1.1-x86_64-apple-darwin.tar.gz` to `wthrr-macos-x86_64`

The additional version specifications are removed from the file names since it is obsolete and even redundant, since the upload is already part of a tag/release with a dedicated version scope.

- This will allow to keep a single link to always get the latest stable release binary via the `releases/latest/download/` url, like:
  [github.com/ttytm/wthrr-the-weathercrab/releases/latest/download/wthrr-linux-x86_64](https://github.com/ttytm/wthrr-the-weathercrab/releases/latest/download/wthrr-linux-x86_64)

- Or a specific version, like so:
  [github.com/ttytm/wthrr-the-weathercrab/releases/download/v1.1.2/wthrr-linux-x86_64](https://github.com/ttytm/wthrr-the-weathercrab/releases/download/v1.1.2/wthrr-linux-x86_64)
  
The exemplary links will work after the next release.