### PR TITLE
⬆️ update MacOS runner versions in GitHub CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         if: matrix.os == 'macos-13'
         run: |
           # mkdir -p /Users/runner/.cargo/bin
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sudo sh -s -- -y
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - name: Run test
         env:
           RUST_BACKTRACE: full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,9 @@ jobs:
         uses: taiki-e/install-action@nextest
       - name: Install cargo, if required
         if: matrix.os == 'macos-13'
-        uses: dtolnay/rust-toolchain@stable
+        run: |
+          mkdir -p /Users/runner/.cargo/bin
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - name: Run test
         env:
           RUST_BACKTRACE: full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         uses: taiki-e/install-action@nextest
       - name: Install cargo, if required
         if: matrix.os == 'macos-12' || matrix.os == 'macos-13'
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        uses: dtolnay/rust-toolchain@stable
       - name: Run test
         env:
           RUST_BACKTRACE: full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-12, macos-13, macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,11 +56,6 @@ jobs:
           key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
-      - name: Install cargo, if required
-        if: matrix.os == 'macos-13'
-        run: |
-          # mkdir -p /Users/runner/.cargo/bin
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - name: Run test
         env:
           RUST_BACKTRACE: full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
+      - name: Install cargo, if required
+        if: matrix.os == 'macos-12' || matrix.os == 'macos-13'
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - name: Run test
         env:
           RUST_BACKTRACE: full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12, macos-13, macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-13, macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
       - name: Install cargo, if required
-        if: matrix.os == 'macos-12' || matrix.os == 'macos-13'
+        if: matrix.os == 'macos-13'
         uses: dtolnay/rust-toolchain@stable
       - name: Run test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
       - name: Install cargo, if required

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,8 @@ jobs:
       - name: Install cargo, if required
         if: matrix.os == 'macos-13'
         run: |
-          mkdir -p /Users/runner/.cargo/bin
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          # mkdir -p /Users/runner/.cargo/bin
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sudo sh -s -- -y
       - name: Run test
         env:
           RUST_BACKTRACE: full

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,14 @@ jobs:
           - os: windows-latest
             target: windows-x86_64
             # Apple targets are not properly signed. Users will have to mark the binaries as secure manually.
-          - os: macos-11
+          - os: macos-12
             target: macos-x86_64
+          - os: macos-13
+            target: macos-x86_64
+          - os: macos-12
+            target: macos-arm64
+          - os: macos-13
+            target: macos-arm64
           - os: macos-latest
             target: macos-arm64
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,6 @@ jobs:
             # Apple targets are not properly signed. Users will have to mark the binaries as secure manually.
           - os: macos-13
             target: macos-x86_64
-          - os: macos-13
-            target: macos-arm64
           - os: macos-latest
             target: macos-arm64
     runs-on: ${{ matrix.os }}
@@ -39,7 +37,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install dependencies
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install dependencies
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,8 @@ jobs:
           - os: windows-latest
             target: windows-x86_64
             # Apple targets are not properly signed. Users will have to mark the binaries as secure manually.
-          - os: macos-12
-            target: macos-x86_64
           - os: macos-13
             target: macos-x86_64
-          - os: macos-12
-            target: macos-arm64
           - os: macos-13
             target: macos-arm64
           - os: macos-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install dependencies
         if: runner.os == 'Linux'
         run: |


### PR DESCRIPTION
@ttytm

This PR fixes #348.  I replaced ``macos-11`` with the newer ``macos-12`` and ``macos-13`` settings.  Furthermore, in ``release.yml``, I also added further compilation targets such that MacOS versions 12 and 13 will both be targeted with ``x86_64`` as well as ``arm64`` architectures.

I would like to ask you to review these changes.