### PR TITLE
🐛 reimplement padding width calculation to fix border placement for languages with varying unicode character widths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,7 +189,7 @@ dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "unicode-width",
+ "unicode-width 0.1.14",
  "windows-sys 0.52.0",
 ]
 
@@ -1408,6 +1408,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1729,6 +1735,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tokio",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ strum = "0.26"
 strum_macros = "0.26"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 scopeguard = "1.2"
+unicode-width = "0.2"
 
 [profile.release]
 strip = true

--- a/src/modules/display/day.rs
+++ b/src/modules/display/day.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use chrono::{Duration, Local};
 use dialoguer::console::style;
+use unicode_width::UnicodeWidthStr;
 
 use crate::modules::{display::hourly::WIDTH, localization::Locales, params::Params, units::Time};
 
@@ -9,7 +10,7 @@ use super::{
 	gui_config::ConfigurableColor,
 	hourly::HourlyForecast,
 	product::Product,
-	utils::lang_len_diff,
+	utils::pad_string_to_width,
 	weathercode::WeatherCode,
 };
 
@@ -39,18 +40,18 @@ impl Day {
 			hourly_forecast,
 		} = self;
 
-		let (gui, lang) = (&params.config.gui, &params.config.language);
+		let gui = &params.config.gui;
+		let width_no_border_pad = WIDTH - 2;
 
 		// Border Top
 		println!("{}", &Edge::Top.fmt(WIDTH, &gui.border).plain_or_bright_black(&gui.color),);
 
 		// Address / Title
 		println!(
-			"{} {: ^WIDTH$} {}",
+			"{} {} {}",
 			Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color),
-			style(&address).bold(),
+			style(pad_string_to_width(&address, width_no_border_pad)).bold(),
 			Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color),
-			WIDTH = WIDTH - 2 - lang_len_diff(&address, lang)
 		);
 
 		// Separator
@@ -70,28 +71,25 @@ impl Day {
 			wmo_code.icon, wmo_code.interpretation, temp_max_min, precipitation_probability_max
 		);
 		println!(
-			"{} {} {: >WIDTH$} {}",
+			"{} {}{} {}",
 			Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color),
-			style(&temperature_and_weathercode).bold(),
+			style(pad_string_to_width(
+				&temperature_and_weathercode,
+				width_no_border_pad - date.width()
+			))
+			.bold(),
 			date,
 			Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color),
-			WIDTH = WIDTH
-				- 3 - lang_len_diff(&wmo_code.interpretation, lang)
-				- temperature_and_weathercode.chars().count()
-				- lang_len_diff(&date, lang)
 		);
 
 		// Apparent Temperature & Sun Rise & Sun Set
 		let sunrise_and_sunset = format!("{sunrise}  {sunset}");
 		println!(
-			"{} {} {: >WIDTH$} {}",
+			"{} {}{} {}",
 			Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color),
-			apparent_temp_max_min,
+			pad_string_to_width(&apparent_temp_max_min, width_no_border_pad - sunrise_and_sunset.width()),
 			sunrise_and_sunset,
 			Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color),
-			WIDTH = WIDTH
-				- 3 - lang_len_diff(&params.texts.weather.feels_like, lang)
-				- apparent_temp_max_min.chars().count()
 		);
 
 		// Hourly Forecast

--- a/src/modules/display/historical.rs
+++ b/src/modules/display/historical.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use chrono::NaiveDate;
 use dialoguer::console::style;
+use unicode_width::UnicodeWidthStr;
 
 use crate::modules::{
 	config::Config,
@@ -15,7 +16,7 @@ use super::{
 	gui_config::ConfigurableColor,
 	hourly::HourlyForecast,
 	product::Product,
-	utils::lang_len_diff,
+	utils::pad_string_to_width,
 	weathercode::WeatherCode,
 };
 
@@ -45,18 +46,18 @@ impl HistoricalWeather {
 			hourly_forecast,
 		} = self;
 
-		let (gui, lang) = (&params.config.gui, &params.config.language);
+		let gui = &params.config.gui;
+		let width_no_border_pad = WIDTH - 2;
 
 		// Border Top
 		println!("{}", &Edge::Top.fmt(WIDTH, &gui.border).plain_or_bright_black(&gui.color));
 
 		// Address / Title
 		println!(
-			"{} {: ^WIDTH$} {}",
+			"{} {} {}",
 			Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color),
-			style(&address).bold(),
+			style(pad_string_to_width(&address, width_no_border_pad)).bold(),
 			Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color),
-			WIDTH = WIDTH - 2 - lang_len_diff(&address, lang)
 		);
 
 		// Separator
@@ -76,28 +77,25 @@ impl HistoricalWeather {
 			wmo_code.icon, wmo_code.interpretation, temp_max_min, precipitation_sum
 		);
 		println!(
-			"{} {} {: >WIDTH$} {}",
+			"{} {}{} {}",
 			Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color),
-			style(&temperature_and_weathercode).bold(),
+			style(pad_string_to_width(
+				&temperature_and_weathercode,
+				width_no_border_pad - date.width()
+			))
+			.bold(),
 			date,
 			Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color),
-			WIDTH = WIDTH
-				- 3 - lang_len_diff(&wmo_code.interpretation, lang)
-				- temperature_and_weathercode.chars().count()
-				- lang_len_diff(&date, lang)
 		);
 
 		// Apparent Temperature & Sun Rise & Sun Set
 		let sunrise_and_sunset = format!("{sunrise}  {sunset}");
 		println!(
-			"{} {} {: >WIDTH$} {}",
+			"{} {}{} {}",
 			Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color),
-			apparent_temp_max_min,
+			pad_string_to_width(&apparent_temp_max_min, width_no_border_pad - sunrise_and_sunset.width()),
 			sunrise_and_sunset,
 			Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color),
-			WIDTH = WIDTH
-				- 3 - lang_len_diff(&params.texts.weather.felt_like, lang)
-				- apparent_temp_max_min.chars().count()
 		);
 
 		// Hourly Overview

--- a/src/modules/display/hourly.rs
+++ b/src/modules/display/hourly.rs
@@ -15,7 +15,7 @@ use super::{
 	graph::Graph,
 	gui_config::ConfigurableColor,
 	product::Product,
-	utils::{lang_len_diff, style_number},
+	utils::{pad_string_to_width, style_number},
 	weathercode::WeatherCode,
 };
 
@@ -48,6 +48,7 @@ impl HourlyForecast {
 		} = self;
 
 		let (units, gui) = (&params.config.units, &params.config.gui);
+		let width_no_border_pad = WIDTH - 2;
 
 		// Blank Line
 		println!(
@@ -68,11 +69,10 @@ impl HourlyForecast {
 
 		// Hourly Forecast Heading
 		println!(
-			"{} {: <WIDTH$} {}",
+			"{} {} {}",
 			Border::L.fmt(&gui.border).plain_or_bright_black(&gui.color),
-			style(&heading).bold(),
+			style(pad_string_to_width(&heading, width_no_border_pad)).bold(),
 			Border::R.fmt(&gui.border).plain_or_bright_black(&gui.color),
-			WIDTH = WIDTH - 2 - lang_len_diff(&heading, &params.config.language)
 		);
 
 		// Day Max/Mix Temperature + Max Precipitation

--- a/src/modules/display/utils.rs
+++ b/src/modules/display/utils.rs
@@ -1,4 +1,5 @@
 use regex::Regex;
+use unicode_width::UnicodeWidthStr;
 
 use crate::modules::display::product::Product;
 
@@ -26,23 +27,13 @@ impl Product<'_> {
 	}
 }
 
-pub fn lang_len_diff(input: &str, lang: &str) -> usize {
-	match &lang[..2] {
-		"zh" => {
-			let re = Regex::new(r"\p{Han}").unwrap();
-			re.find_iter(input).count()
-		}
-		"ko" => {
-			let re = Regex::new(r"[\u3131-\uD79D\w]").unwrap();
-			let nu = Regex::new(r"[-]?\d+(\.\d+)?").unwrap();
-			re.find_iter(input).count() - nu.find_iter(input).count()
-		}
-		"ja" => {
-			let re = Regex::new(r"[ぁ-んァ-ン\w]").unwrap();
-			let nu = Regex::new(r"[-]?\d+(\.\d+)?").unwrap();
-			re.find_iter(input).count() - nu.find_iter(input).count()
-		}
-		_ => 0,
+pub fn pad_string_to_width(s: &str, total_width: usize) -> String {
+	let current_width = s.width(); // Effective width of the string
+	if current_width >= total_width {
+		s.to_string() // No padding needed if already wide enough
+	} else {
+		let padding = total_width - current_width;
+		format!("{}{}", s, " ".repeat(padding))
 	}
 }
 


### PR DESCRIPTION
Resolves border bugs mentioned in #357

![Screenshot_20241003_182137](https://github.com/user-attachments/assets/51ef1f86-97be-4ff7-bf26-1f1f799c0948)


The enhancement regarding the translations the issue is mentioning will be tracked separately.