### PR TITLE
✨ add `--completions <shell>` arg to generate completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2e663e3e3bed2d32d065a8404024dad306e699a04263ec59919529f803aee9"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1748,6 +1757,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "clap_complete",
  "dialoguer",
  "dirs",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ strum_macros = "0.26"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 scopeguard = "1.2"
 unicode-width = "0.2"
+clap_complete = "4.5.40"
 
 [dev-dependencies]
 strip-ansi-escapes = "0.2"

--- a/src/modules/args.rs
+++ b/src/modules/args.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Result};
 use chrono::NaiveDate;
 use clap::{Parser, ValueEnum};
+use clap_complete::Shell;
 use serde::{Deserialize, Serialize};
 use strum_macros::AsRefStr;
 
@@ -34,6 +35,10 @@ pub struct Cli {
 	/// Wipe wthrr's configuration data
 	#[arg(short, long, group = "config_file_action")]
 	pub reset: bool,
+
+	/// Generate shell completions
+	#[arg(long, value_name = "SHELL")]
+	pub completions: Option<Shell>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, AsRefStr, Serialize, Deserialize, Hash)]

--- a/src/modules/params.rs
+++ b/src/modules/params.rs
@@ -2,6 +2,8 @@ use std::collections::HashSet;
 
 use anyhow::{Context, Result};
 use chrono::NaiveDate;
+use clap::CommandFactory;
+use clap_complete::generate;
 use dialoguer::{theme::ColorfulTheme, Confirm, Select};
 
 use super::{
@@ -21,6 +23,13 @@ pub struct Params {
 
 impl Params {
 	pub async fn merge(config: &Config, args: &Cli) -> Result<Self> {
+		if let Some(shell) = args.completions {
+			let mut cmd = Cli::command();
+			let bin_name = cmd.get_name().to_string();
+			generate(shell, &mut cmd, bin_name, &mut std::io::stdout());
+			std::process::exit(0);
+		}
+
 		let language = match &args.language {
 			Some(lang) => lang.to_string(),
 			None => config.language.clone(),


### PR DESCRIPTION
Allows to generate shell completions to simplify usage:

E.g. while typing: 
```
wthrr -
```
![Screenshot_20241219_221716](https://github.com/user-attachments/assets/575e3626-1ff1-42d9-9355-311f1011798d)


```
wthrr -f
```
![Screenshot_20241219_221808](https://github.com/user-attachments/assets/4e56a0a2-2f56-48ff-9786-0c3d5dbf0d83)


- [ ] update docs